### PR TITLE
Remove React Strict Mode

### DIFF
--- a/templates/default/src/main.tsx
+++ b/templates/default/src/main.tsx
@@ -1,16 +1,14 @@
-import { AppRoot } from "@dynatrace/strato-components-preview";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { AppRoot } from "@dynatrace/strato-components-preview";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app/App";
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 root.render(
-  <React.StrictMode>
-    <AppRoot>
-      <BrowserRouter basename="ui">
-        <App />
-      </BrowserRouter>
-    </AppRoot>
-  </React.StrictMode>
+  <AppRoot>
+    <BrowserRouter basename="ui">
+      <App />
+    </BrowserRouter>
+  </AppRoot>
 );

--- a/templates/empty/src/main.tsx
+++ b/templates/empty/src/main.tsx
@@ -6,11 +6,9 @@ import { App } from "./app/App";
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 root.render(
-  <React.StrictMode>
-    <AppRoot>
-      <BrowserRouter basename="ui">
-        <App />
-      </BrowserRouter>
-    </AppRoot>
-  </React.StrictMode>
+  <AppRoot>
+    <BrowserRouter basename="ui">
+      <App />
+    </BrowserRouter>
+  </AppRoot>
 );


### PR DESCRIPTION
https://dt-rnd.atlassian.net/browse/APPDEV-8259

As mentioned in the ticket, we need to remove the strict mode added on the templates while upgrading to react V18.

To test this, simply run both templates and make sure everything works fine