### PR TITLE
fix: Add tsconfig on each template for eslint

### DIFF
--- a/templates/default/tsconfig.eslint.json
+++ b/templates/default/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/templates/empty/tsconfig.eslint.json
+++ b/templates/empty/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
On each template, actions were added into the `exclude` array of the `tsconfig`. This makes eslint to not know where the `action` folder is.

In order to fix this issue, we can simply add excludes on each `tsconfig.eslint.json` to override the base one.

How to test this? :mag: 

The easiest way is to simply grab a project that is currently having the issue and then copy-paste the exclude given in this PR. After that, reload vscode and the error should be gone.