### PR TITLE
Fix invalid JSON by removing trailing comma

### DIFF
--- a/templates/default/.vscode/extensions.json
+++ b/templates/default/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "dynatrace.dynatrace-apps",
+        "dynatrace.dynatrace-apps"
     ]
 }

--- a/templates/empty/.vscode/extensions.json
+++ b/templates/empty/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "dynatrace.dynatrace-apps",
+        "dynatrace.dynatrace-apps"
     ]
 }


### PR DESCRIPTION
VS Code is happily parsing the invalid `extensions.json`-file, but IDEs will show the trailing comma as a syntax error which is annoying.