### PR TITLE
add typescript as a dev dependency

### DIFF
--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -46,6 +46,7 @@
     "eslint": "^8.15.0",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-react": "^7.29.4",
-    "eslint-plugin-react-hooks": "^4.5.0"
+    "eslint-plugin-react-hooks": "^4.5.0",
+    "typescript": "5.6.2"
   }
 }

--- a/templates/empty/package.json
+++ b/templates/empty/package.json
@@ -46,6 +46,7 @@
     "eslint": "^8.15.0",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-react": "^7.29.4",
-    "eslint-plugin-react-hooks": "^4.5.0"
+    "eslint-plugin-react-hooks": "^4.5.0",
+    "typescript": "5.6.2"
   }
 }


### PR DESCRIPTION
dt-app cli has typescript as a peer dependency. This means that we need to add typescript here as a dev dependency because some package managers (yarn) will not install typescript by default