### PR TITLE
Add deprecation linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run lint:default
+npm run lint:empty

--- a/package.json
+++ b/package.json
@@ -2,8 +2,14 @@
   "name": "cli-templates",
   "devDependencies": {
     "@types/lodash.kebabcase": "^4.1.7",
+    "husky": "^8.0.0",
     "lodash.kebabcase": "^4.1.1",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.2"
+  },
+  "scripts": {
+    "prepare": "husky",
+    "lint:default": "eslint templates/default -c templates/default/.eslintrc --ext .ts,.tsx",
+    "lint:empty": "eslint templates/empty -c templates/empty/.eslintrc --ext .ts,.tsx"
   }
 }

--- a/templates/default/.eslintrc
+++ b/templates/default/.eslintrc
@@ -7,7 +7,7 @@
     "project": ["./tsconfig.eslint.json"]
   },
   "plugins": ["@typescript-eslint", "react-hooks", "@microsoft/eslint-plugin-sdl", "no-secrets"],
-  "extends": ["plugin:react/recommended", "plugin:@typescript-eslint/recommended", "plugin:@microsoft/eslint-plugin-sdl/recommended", "plugin:@microsoft/eslint-plugin-sdl/react"],
+  "extends": ["plugin:react/recommended", "plugin:@typescript-eslint/recommended", "plugin:@microsoft/eslint-plugin-sdl/recommended", "plugin:@microsoft/eslint-plugin-sdl/react", "plugin:deprecation/recommended"],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -30,17 +30,26 @@
     "no-restricted-imports": [
       "error",
       {
-        "name": "@dynatrace/strato-components-preview",
-        "message":
-          "Please import from one of the sub packages, e.g. '@dynatrace/strato-components-preview/buttons' instead.",
-      },
-      {
-        "name": "@dynatrace/strato-components",
-        "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-components/buttons' instead.",
-      },
-      {
-        "name": "@dynatrace/strato-design-tokens",
-        "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-design-tokens/colors' instead.",
+        "paths": [
+          {
+            "name": "@dynatrace/strato-components-preview",
+            "message":
+              "Please import from one of the sub packages, e.g. '@dynatrace/strato-components-preview/buttons' instead.",
+          },
+          {
+            "name": "@dynatrace/strato-components",
+            "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-components/buttons' instead.",
+          },
+          {
+            "name": "@dynatrace/strato-design-tokens",
+            "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-design-tokens/colors' instead.",
+          }
+        ],
+        "patterns": [{
+          "group": ["@dynatrace/strato-components-preview","@dynatrace/strato-components-preview/*"],
+          "importNames": ["Button", "Flex", "ProgressCircle", "Grid", "Divider", "Text", "Heading", "ExternalLink", "Link", "Container", "Strong", "Skeleton"],
+          "message": "Please use the component from @dynatrace/strato-components instead."
+        }]
       }
     ]
   },

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.15.0",
+    "eslint-plugin-deprecation": "^3.0.0",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",

--- a/templates/empty/.eslintrc
+++ b/templates/empty/.eslintrc
@@ -7,7 +7,7 @@
     "project": ["./tsconfig.eslint.json"]
   },
   "plugins": ["@typescript-eslint", "react-hooks", "@microsoft/eslint-plugin-sdl", "no-secrets"],
-  "extends": ["plugin:react/recommended", "plugin:@typescript-eslint/recommended", "plugin:@microsoft/eslint-plugin-sdl/recommended", "plugin:@microsoft/eslint-plugin-sdl/react"],
+  "extends": ["plugin:react/recommended", "plugin:@typescript-eslint/recommended", "plugin:@microsoft/eslint-plugin-sdl/recommended", "plugin:@microsoft/eslint-plugin-sdl/react", "plugin:deprecation/recommended"],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -30,17 +30,26 @@
     "no-restricted-imports": [
       "error",
       {
-        "name": "@dynatrace/strato-components-preview",
-        "message":
-          "Please import from one of the sub packages, e.g. '@dynatrace/strato-components-preview/buttons' instead.",
-      },
-      {
-        "name": "@dynatrace/strato-components",
-        "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-components/buttons' instead.",
-      },
-      {
-        "name": "@dynatrace/strato-design-tokens",
-        "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-design-tokens/colors' instead.",
+        "paths": [
+          {
+            "name": "@dynatrace/strato-components-preview",
+            "message":
+              "Please import from one of the sub packages, e.g. '@dynatrace/strato-components-preview/buttons' instead.",
+          },
+          {
+            "name": "@dynatrace/strato-components",
+            "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-components/buttons' instead.",
+          },
+          {
+            "name": "@dynatrace/strato-design-tokens",
+            "message": "Please import from one of the sub packages, e.g. '@dynatrace/strato-design-tokens/colors' instead.",
+          }
+        ],
+        "patterns": [{
+          "group": ["@dynatrace/strato-components-preview","@dynatrace/strato-components-preview/*"],
+          "importNames": ["Button", "Flex", "ProgressCircle", "Grid", "Divider", "Text", "Heading", "ExternalLink", "Link", "Container", "Strong", "Skeleton"],
+          "message": "Please use the component from @dynatrace/strato-components instead."
+        }]
       }
     ]
   },

--- a/templates/empty/package.json
+++ b/templates/empty/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.15.0",
+    "eslint-plugin-deprecation": "^3.0.0",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
To test this you can install an older verison of strato icons and import the ErrorIcon + Use components like Flex from the preview package (might also need an older version) that were moved to strato-components

<img width="1279" alt="Screenshot 2024-10-01 at 15 58 58" src="https://github.com/user-attachments/assets/7522aa1b-e50d-4e13-ab26-0dc1616c695f">
