### PR TITLE
fix: update dt-app-mcp tool names in AGENTS.md templates

### DIFF
--- a/templates/default/AGENTS.md
+++ b/templates/default/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## DQL - Dynatrace Query Language
 
-Before writing any DQL query, the agent must always use the knowledge base (`dql_search` tool) to search for relevant DQL documentation, syntax, and examples, whenever the tool is available.
+Before writing any DQL query, the agent must always use the knowledge base (`get_dql_knowledgebase` tool) to search for relevant DQL documentation, syntax, and examples, whenever the tool is available.
 
 ## UI Components - Strato
 
 Before using any Strato UI component, the agent must always use the knowledge base tools to search for relevant component documentation and usage examples, whenever the tools are available:
-- Use the `strato_search` tool to search for available Strato components by name or keyword.
-- Use the `strato_get_component` tool to retrieve detailed documentation, props, and code examples for a specific component.
-- Use the `strato_get_usecase_details` tool to get code for specific component use cases and patterns.
+- Use the `list_strato_components` tool to search for available Strato components by name or keyword.
+- Use the `get_strato_component` tool to retrieve detailed documentation, props, and code examples for a specific component.
+- Use the `get_strato_usecases` tool to get code for specific component use cases and patterns.
 
 ## Project Overview
 This repository contains a **Dynatrace App** built with the Dynatrace App Toolkit "dt-app", running on **Dynatrace AppEngine**. Use the **App Toolkit** during development and CI (`dt-app dev`, `dt-app build`, `dt-app deploy`, `dt-app publish`).

--- a/templates/empty/AGENTS.md
+++ b/templates/empty/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## DQL - Dynatrace Query Language
 
-Before writing any DQL query, the agent must always use the knowledge base (`dql_search` tool) to search for relevant DQL documentation, syntax, and examples, whenever the tool is available.
+Before writing any DQL query, the agent must always use the knowledge base (`get_dql_knowledgebase` tool) to search for relevant DQL documentation, syntax, and examples, whenever the tool is available.
 
 ## UI Components - Strato
 
 Before using any Strato UI component, the agent must always use the knowledge base tools to search for relevant component documentation and usage examples, whenever the tools are available:
-- Use the `strato_search` tool to search for available Strato components by name or keyword.
-- Use the `strato_get_component` tool to retrieve detailed documentation, props, and code examples for a specific component.
-- Use the `strato_get_usecase_details` tool to get code for specific component use cases and patterns.
+- Use the `list_strato_components` tool to search for available Strato components by name or keyword.
+- Use the `get_strato_component` tool to retrieve detailed documentation, props, and code examples for a specific component.
+- Use the `get_strato_usecases` tool to get code for specific component use cases and patterns.
 
 ## Project Overview
 This repository contains a **Dynatrace App** built with the Dynatrace App Toolkit "dt-app", running on **Dynatrace AppEngine**. Use the **App Toolkit** during development and CI (`dt-app dev`, `dt-app build`, `dt-app deploy`, `dt-app publish`).


### PR DESCRIPTION
## Summary

- Update `dql_search` → `get_dql_knowledgebase`
- Update `strato_search` → `list_strato_components`
- Update `strato_get_component` → `get_strato_component`
- Update `strato_get_usecase_details` → `get_strato_usecases`

Applied to both `templates/default/AGENTS.md` and `templates/empty/AGENTS.md`.

## Test plan
- [ ] Verify tool names match the current `dt-app-mcp` MCP server tool definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)