### PR TITLE
fix react-hooks version

### DIFF
--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -24,7 +24,7 @@
     "@dynatrace-sdk/client-query": "^1.26.0",
     "@dynatrace-sdk/error-handlers": "^1.3.1",
     "@dynatrace-sdk/navigation": "^2.2.1",
-    "@dynatrace-sdk/react-hooks": "^1.15.0",
+    "@dynatrace-sdk/react-hooks": "^1.14.1",
     "@dynatrace-sdk/user-preferences": "^1.1.4",
     "@dynatrace/strato-components": "^3.9.0",
     "@dynatrace/strato-design-tokens": "^1.5.1",

--- a/templates/empty/package.json
+++ b/templates/empty/package.json
@@ -24,7 +24,7 @@
     "@dynatrace-sdk/client-query": "^1.26.0",
     "@dynatrace-sdk/error-handlers": "^1.3.1",
     "@dynatrace-sdk/navigation": "^2.2.1",
-    "@dynatrace-sdk/react-hooks": "^1.15.0",
+    "@dynatrace-sdk/react-hooks": "^1.14.1",
     "@dynatrace-sdk/user-preferences": "^1.1.4",
     "@dynatrace/strato-components": "^3.9.0",
     "@dynatrace/strato-design-tokens": "^1.5.1",


### PR DESCRIPTION
This PR fixes the templates such that @dynatrace-sdk/react-hooks is changed to an older version matching the public npm registry