### PR TITLE
Add build quality rules to AGENTS.md templates

### DIFF
--- a/templates/default/AGENTS.md
+++ b/templates/default/AGENTS.md
@@ -11,6 +11,12 @@ Before using any Strato UI component, the agent must always use the knowledge ba
 - Use the `get_strato_component` tool to retrieve detailed documentation, props, and code examples for a specific component.
 - Use the `get_strato_usecases` tool to get code for specific component use cases and patterns.
 
+## Build Quality Rules
+
+- **Important**: Use Strato Design System components wherever possible!
+- **Important**: `npm run build` must pass without errors!
+- **Important**: `npm run lint` must pass without errors!
+
 ## Project Overview
 This repository contains a **Dynatrace App** built with the Dynatrace App Toolkit "dt-app", running on **Dynatrace AppEngine**. Use the **App Toolkit** during development and CI (`dt-app dev`, `dt-app build`, `dt-app deploy`, `dt-app publish`).
 

--- a/templates/empty/AGENTS.md
+++ b/templates/empty/AGENTS.md
@@ -11,6 +11,12 @@ Before using any Strato UI component, the agent must always use the knowledge ba
 - Use the `get_strato_component` tool to retrieve detailed documentation, props, and code examples for a specific component.
 - Use the `get_strato_usecases` tool to get code for specific component use cases and patterns.
 
+## Build Quality Rules
+
+- **Important**: Use Strato Design System components wherever possible!
+- **Important**: `npm run build` must pass without errors!
+- **Important**: `npm run lint` must pass without errors!
+
 ## Project Overview
 This repository contains a **Dynatrace App** built with the Dynatrace App Toolkit "dt-app", running on **Dynatrace AppEngine**. Use the **App Toolkit** during development and CI (`dt-app dev`, `dt-app build`, `dt-app deploy`, `dt-app publish`).
 


### PR DESCRIPTION
## Summary

- Adds a `## Build Quality Rules` section to both `templates/default/AGENTS.md` and `templates/empty/AGENTS.md`
- Rules instruct AI coding agents to prefer Strato components, keep `npm run build` green, and keep `npm run lint` clean
- Section is placed after the Strato tool-use instructions and before `## Project Overview` for early visibility

## Test plan

- [ ] Review the added section in both template files
- [ ] Verify the section appears in the correct position (after Strato tool guidance, before Project Overview)
- [ ] Run `dt-app create` with each template and confirm AGENTS.md in the generated app contains the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)