### PR TITLE
APPDEV-18820: Automate dependency version bumps via Renovate

### DIFF
--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -1,0 +1,15 @@
+name: Renovate config
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate renovate.json
+        run: npx --yes --package renovate -- renovate-config-validator --strict

--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ To work directly with the source in the templates directory, follow these steps:
 ```bash
   npx dt-app create --environment-url YOUR_ENVIRONMENT_URL --template-dir=../cli-templates/templates/default
 ```
+
+## Dependency updates
+
+Dependency versions in the templates are kept up to date by [Renovate](https://docs.renovatebot.com/)
+(configured in [`renovate.json`](./renovate.json)). Bumping them manually every sprint is no longer necessary.
+
+Renovate runs weekly (Monday before 6am, Europe/Vienna) and opens one pull request per group:
+
+| Group                    | Contents                                                      |
+| ------------------------ | ------------------------------------------------------------- |
+| Dynatrace dependencies   | `@dynatrace/*` and `@dynatrace-sdk/*`                         |
+| 3rd party dependencies   | all remaining `dependencies`                                  |
+| dev dependencies         | all `devDependencies`, plus GitHub Actions used by workflows  |
+
+Notes:
+
+- Version ranges are never pinned. Renovate bumps the version a range points at while keeping the
+  range operator, so `^1.1.4` becomes `^1.1.5` and the exact `react-intl` pin stays exact.
+- Major updates arrive as their own pull request per group (for example `renovate/major-third-party-dependencies`)
+  so that breaking changes are never mixed into a routine patch update.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "ignorePresets": ["group:monorepos", "group:recommended"],
+  "timezone": "Europe/Vienna",
+  "schedule": ["before 6am on monday"],
+  "dependencyDashboard": false,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 10,
+  "rangeStrategy": "bump",
+  "ignorePaths": ["**/node_modules/**"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["dependencies"],
+      "groupName": "3rd party dependencies",
+      "groupSlug": "third-party-dependencies"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "dev dependencies",
+      "groupSlug": "dev-dependencies"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "dev dependencies",
+      "groupSlug": "dev-dependencies"
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchPackageNames": ["@dynatrace/**", "@dynatrace-sdk/**"],
+      "groupName": "Dynatrace dependencies",
+      "groupSlug": "dynatrace-dependencies"
+    },
+    {
+      "description": "The overrides block declares deliberate peer-dependency floors, not real dependencies. Bumping them would needlessly narrow the accepted range.",
+      "matchDepTypes": ["overrides"],
+      "enabled": false
+    },
+    {
+      "description": "engines.node is the minimum Node version supported by generated apps. Raising it is a breaking change for template consumers, so it stays a manual decision.",
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Replaces the manual per-sprint version bump with a Renovate config that opens one PR per group: Dynatrace deps, 3rd party deps, and dev deps.